### PR TITLE
Fixes script paths for updated versions of Terraform

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ replica_backup_policy_level = "bronze"
 ### Variable Specific Conisderions
 - Compute ssh keys to later log into instances. Paths to the keys should be provided in variables `ssh_public_key` and `ssh_private_key`.
 - Variable `compute_nsg_name` is an optional network security group that can be attached.
-- Variable `redis_version` may be set to any of the supported version of Redis at the time of creating this brick `(6.2.5, 6.0.15, 5.0.13)` Source: [Redis endoflife](https://endoflife.date/redis)
+- Variable `redis_version` may be set to any of the supported version of Redis at the time of creating this brick `(6.2.6, 6.0.16, 5.0.14)` Source: [Redis endoflife](https://endoflife.date/redis)
 - Variable `redis_replica_count` determines how many replica instance are provisioned. This value has been tested between `1-30`, however a minimum of `3` is recommended.
 - Variable `instance_backup_policy_level` specifies the name of the backup policy used on the instance boot volumes.
 - Variables `master_backup_policy_level` and `replica_backup_policy_level` specificy the name of the backup policy used on the ISCSI disks storing data and log files on the master and replica servers respectively.

--- a/outputs.tf
+++ b/outputs.tf
@@ -6,12 +6,10 @@
 
 output "redis_master_server" {
   description = "Redis Master Instance"
-  sensitive   = true
   value = oci_core_instance.redis_master
 }
 
 output "redis_replica_servers" {
   description = "Redis Replica Instances"
-  sensitive   = true
   value = oci_core_instance.redis_replica[*]
 }

--- a/redisconfig.tf
+++ b/redisconfig.tf
@@ -51,7 +51,7 @@ resource "null_resource" "master_install_redis_binaries" {
     }
 
     inline = [
-      "sudo rm -rf ~/install_redis_binaries.sh"
+      "sudo rm -rf /tmp/install_redis_binaries.sh"
     ]
   }
 
@@ -64,7 +64,7 @@ resource "null_resource" "master_install_redis_binaries" {
     }
 
     content     = data.template_file.install_redis_binaries_sh.rendered
-    destination = "~/install_redis_binaries.sh"
+    destination = "/tmp/install_redis_binaries.sh"
   }
 
   provisioner "remote-exec" {
@@ -76,8 +76,8 @@ resource "null_resource" "master_install_redis_binaries" {
     }
 
     inline = [
-      "chmod +x ~/install_redis_binaries.sh",
-      "sudo ~/install_redis_binaries.sh"
+      "chmod +x /tmp/install_redis_binaries.sh",
+      "sudo /tmp/install_redis_binaries.sh"
     ]
   }
 }
@@ -103,7 +103,7 @@ resource "null_resource" "replica_install_redis_binaries" {
     }
 
     inline = [
-      "sudo rm -rf ~/install_redis_binaries.sh"
+      "sudo rm -rf /tmp/install_redis_binaries.sh"
     ]
   }
 
@@ -116,7 +116,7 @@ resource "null_resource" "replica_install_redis_binaries" {
     }
 
     content     = data.template_file.install_redis_binaries_sh.rendered
-    destination = "~/install_redis_binaries.sh"
+    destination = "/tmp/install_redis_binaries.sh"
   }
 
   provisioner "remote-exec" {
@@ -128,8 +128,8 @@ resource "null_resource" "replica_install_redis_binaries" {
     }
 
     inline = [
-      "chmod +x ~/install_redis_binaries.sh",
-      "sudo ~/install_redis_binaries.sh"
+      "chmod +x /tmp/install_redis_binaries.sh",
+      "sudo /tmp/install_redis_binaries.sh"
     ]
   }
 }
@@ -149,7 +149,7 @@ resource "null_resource" "redis_setup_master" {
     }
 
     inline = [
-      "sudo rm -rf ~/redis_setup_master.sh"
+      "sudo rm -rf /tmp/redis_setup_master.sh"
     ]
   }
 
@@ -162,7 +162,7 @@ resource "null_resource" "redis_setup_master" {
     }
 
     content     = data.template_file.redis_setup_master_sh.rendered
-    destination = "~/redis_setup_master.sh"
+    destination = "/tmp/redis_setup_master.sh"
   }
 
   provisioner "remote-exec" {
@@ -174,8 +174,8 @@ resource "null_resource" "redis_setup_master" {
     }
 
     inline = [
-      "chmod +x ~/redis_setup_master.sh",
-      "sudo ~/redis_setup_master.sh"
+      "chmod +x /tmp/redis_setup_master.sh",
+      "sudo /tmp/redis_setup_master.sh"
     ]
   }
 }
@@ -196,7 +196,7 @@ resource "null_resource" "redis_setup_replicas" {
     }
 
     inline = [
-      "sudo rm -rf ~/redis_setup_replicas.sh"
+      "sudo rm -rf /tmp/redis_setup_replicas.sh"
     ]
   }
 
@@ -209,7 +209,7 @@ resource "null_resource" "redis_setup_replicas" {
     }
 
     content     = data.template_file.redis_setup_replicas_sh[count.index].rendered
-    destination = "~/redis_setup_replicas.sh"
+    destination = "/tmp/redis_setup_replicas.sh"
   }
 
   provisioner "remote-exec" {
@@ -221,8 +221,8 @@ resource "null_resource" "redis_setup_replicas" {
     }
 
     inline = [
-      "chmod +x ~/redis_setup_replicas.sh",
-      "sudo ~/redis_setup_replicas.sh"
+      "chmod +x /tmp/redis_setup_replicas.sh",
+      "sudo /tmp/redis_setup_replicas.sh"
     ]
   }
 }
@@ -242,7 +242,7 @@ resource "null_resource" "sentinel_setup_master" {
     }
 
     inline = [
-      "sudo rm -rf ~/sentinel_setup.sh"
+      "sudo rm -rf /tmp/sentinel_setup.sh"
     ]
   }
 
@@ -255,7 +255,7 @@ resource "null_resource" "sentinel_setup_master" {
     }
 
     source      = "${path.module}/scripts/sentinel_setup.sh"
-    destination = "~/sentinel_setup.sh"
+    destination = "/tmp/sentinel_setup.sh"
   }
 
   provisioner "remote-exec" {
@@ -267,8 +267,8 @@ resource "null_resource" "sentinel_setup_master" {
     }
 
     inline = [
-      "chmod +x ~/sentinel_setup.sh",
-      "sudo ~/sentinel_setup.sh ${oci_core_instance.redis_master.private_ip} ${tonumber(var.redis_replica_count)}"
+      "chmod +x /tmp/sentinel_setup.sh",
+      "sudo /tmp/sentinel_setup.sh ${oci_core_instance.redis_master.private_ip} ${tonumber(var.redis_replica_count)}"
     ]
   }
 }
@@ -289,7 +289,7 @@ resource "null_resource" "sentinel_setup_replicas" {
     }
 
     inline = [
-      "sudo rm -rf ~/sentinel_setup.sh"
+      "sudo rm -rf /tmp/sentinel_setup.sh"
     ]
   }
 
@@ -302,7 +302,7 @@ resource "null_resource" "sentinel_setup_replicas" {
     }
 
     source      = "${path.module}/scripts/sentinel_setup.sh"
-    destination = "~/sentinel_setup.sh"
+    destination = "/tmp/sentinel_setup.sh"
   }
 
   provisioner "remote-exec" {
@@ -314,8 +314,8 @@ resource "null_resource" "sentinel_setup_replicas" {
     }
 
     inline = [
-      "chmod +x ~/sentinel_setup.sh",
-      "sudo ~/sentinel_setup.sh ${oci_core_instance.redis_master.private_ip} ${tonumber(var.redis_replica_count)}"
+      "chmod +x /tmp/sentinel_setup.sh",
+      "sudo /tmp/sentinel_setup.sh ${oci_core_instance.redis_master.private_ip} ${tonumber(var.redis_replica_count)}"
     ]
   }
 }


### PR DESCRIPTION
Terraform seems to not longer allow for `~/` in the paths for provisioning files. 

Creating all scripts in the `/tmp` directory handles this nicely.


I have also updated and tested the latest versions of Redis and updated the README accordingly.